### PR TITLE
fix: remove duplicate hooks reference from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -14,6 +14,5 @@
     "./agents/design-reviewer.md",
     "./agents/ui-developer.md",
     "./agents/test-engineer.md"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }


### PR DESCRIPTION
## Problem

Installing the plugin and running `/reload-plugins` in Claude Code reports a load error:

```
Failed to load hooks from .../hooks/hooks.json: Duplicate hooks file detected:
./hooks/hooks.json resolves to already-loaded file
```

Claude Code automatically loads `hooks/hooks.json` from its standard path. The explicit `"hooks": "./hooks/hooks.json"` entry in `.claude-plugin/plugin.json` makes the same file load a second time — the manifest `hooks` field is only meant for *additional* hook files beyond the standard one.

## Fix

Remove the `hooks` field from `.claude-plugin/plugin.json`. Hooks stay fully active via the auto-load path; the load error disappears.

Verified locally: after this change `/reload-plugins` loads the plugin with 0 errors and the SessionStart/UserPromptSubmit hooks still fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)